### PR TITLE
Chore: Update API base url pointing to SA test account

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASE_URL = 'https://ebkqjitsgh.execute-api.eu-central-1.amazonaws.com/prod';
+const BASE_URL = 'https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test'; // hosted in SA test account
 
 export function getListings() {
   return axios(`${BASE_URL}/listings/`);


### PR DESCRIPTION
Postman collection available in the ticket comments [here](https://homegate.atlassian.net/browse/RBD-1589).

Endpoints available in hg-notification-test account:

- https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test/listings
- https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test/listings/2
- https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test/listings/5/similar


![Screenshot 2024-03-14 at 10 04 08](https://github.com/thomas-hain/fe-coding-assignment/assets/141332515/c2a42d85-eb44-4d8e-bcc7-259af780a267)
