### PR TITLE
chore: update base url

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASE_URL = 'https://ebkqjitsgh.execute-api.eu-central-1.amazonaws.com/prod';
+const BASE_URL = 'https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test'; // hosted in SA test account
 
 export function getListings() {
   return axios(`${BASE_URL}/listings/`);

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASE_URL = 'https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test'; // hosted in SA test account
+const BASE_URL = 'https://amgmqmmo4b.execute-api.eu-central-1.amazonaws.com/prod'; // hosted in aws_re-srp-test
 
 export function getListings() {
   return axios(`${BASE_URL}/listings`);

--- a/src/api.js
+++ b/src/api.js
@@ -3,5 +3,5 @@ import axios from 'axios';
 const BASE_URL = 'https://2yahugzd4a.execute-api.eu-central-1.amazonaws.com/test'; // hosted in SA test account
 
 export function getListings() {
-  return axios(`${BASE_URL}/listings/`);
+  return axios(`${BASE_URL}/listings`);
 }


### PR DESCRIPTION
We have moved the endpoint to the new AWS account because:

- The old AWS account (TEST seeker app) will be removed soon as we successfully migrated SRP and PDP to vue 3 in separate accounts.
- Node 20 is going to be depreciated soon. The migrated lambda is moved to the new account `aws_re-srp-test`.